### PR TITLE
Update web component version to 5.0.2

### DIFF
--- a/vcf-date-range-picker/src/main/java/com/vaadin/componentfactory/EnhancedDateRangePicker.java
+++ b/vcf-date-range-picker/src/main/java/com/vaadin/componentfactory/EnhancedDateRangePicker.java
@@ -58,7 +58,7 @@ import org.jsoup.internal.StringUtil;
 @JavaScript("./date-fns-limited.min.js")
 @JavaScript("./enhancedDateRangePickerConnector.js")
 @Tag("vcf-date-range-picker")
-@NpmPackage(value = "@vaadin-component-factory/vcf-date-range-picker", version = "5.0.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-date-range-picker", version = "5.0.2")
 @JsModule("@vaadin-component-factory/vcf-date-range-picker/vcf-date-range-picker.js")
 public class EnhancedDateRangePicker extends  AbstractSinglePropertyField<EnhancedDateRangePicker, DateRange>
         implements HasSize, HasValidation, HasComponents, HasClearButton, HasLabel {


### PR DESCRIPTION
Close #45

Updates web-component version to 5.0.2. This version fixes the issue on method `removePreselectionById  `which is the client-side method being call on `removePresetByIds` execution. See https://github.com/vaadin-component-factory/vcf-date-range-picker/pull/43