### PR TITLE
Vaadin 25 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,9 @@ node_modules/
 webpack.generated.js
 vcf-date-range-picker-demo/frontend/generated
 vcf-date-range-picker-demo/frontend/index.html
-vcf-date-range-picker-demo/src/main/dev-bundle
+vcf-date-range-picker-demo/src/main/bundles
 tsconfig.json
 types.d.ts
 vite.config.ts
+vite.generated.ts
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This component is part of Vaadin Component Factory
 - Version 3.x.x supports Vaadin 23.0.x
 - Version 4.x.x supports Vaadin 23.1 & 23.2
 - Version 5.x.x supports Vaadin 24
+- Version 6.x.x supports Vaadin 25
 
 ## Running the component demo
 Run from the command line:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>date-range-picker-parent</artifactId>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Date Range Picker Parent</name>
 

--- a/vcf-date-range-picker-demo/pom.xml
+++ b/vcf-date-range-picker-demo/pom.xml
@@ -49,14 +49,7 @@
             <artifactId>vcf-date-range-picker</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
-        <!-- demo specific -->
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>flow-component-demo-helpers</artifactId>
-            <version>9.0.12</version>
-        </dependency>
-
+       
         <!-- externals -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/vcf-date-range-picker-demo/pom.xml
+++ b/vcf-date-range-picker-demo/pom.xml
@@ -17,9 +17,9 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.2.0</vaadin.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <vaadin.version>25.0.2</vaadin.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
     </properties>

--- a/vcf-date-range-picker-demo/pom.xml
+++ b/vcf-date-range-picker-demo/pom.xml
@@ -9,7 +9,7 @@
     <packaging>war</packaging>
     <name>Date Range Picker Demo</name>
 
-    <version>5.0.3-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <inceptionYear>2021</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-date-range-picker-demo/pom.xml
+++ b/vcf-date-range-picker-demo/pom.xml
@@ -95,13 +95,13 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.14</version>
+                <version>11.0.26</version>
          		<configuration>
                     <scan>2</scan>
                     <!-- Use war output directory to get the webpack files -->
-                    <webAppConfig>
+                    <webApp>
                         <allowDuplicateFragmentNames>true</allowDuplicateFragmentNames>
-                    </webAppConfig>
+                    </webApp>
                 </configuration>
             </plugin>
             <plugin>

--- a/vcf-date-range-picker-demo/pom.xml
+++ b/vcf-date-range-picker-demo/pom.xml
@@ -37,6 +37,12 @@
     </dependencyManagement>
 
     <dependencies>
+    	 <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev</artifactId>
+            <optional>true</optional>
+        </dependency>
+    
         <!-- Component -->
         <dependency>
             <groupId>com.vaadin.componentfactory</groupId>

--- a/vcf-date-range-picker-demo/src/main/java/com/vaadin/componentfactory/demo/AppShellConfiguratorImpl.java
+++ b/vcf-date-range-picker-demo/src/main/java/com/vaadin/componentfactory/demo/AppShellConfiguratorImpl.java
@@ -1,0 +1,10 @@
+package com.vaadin.componentfactory.demo;
+
+import com.vaadin.flow.component.dependency.StyleSheet;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@StyleSheet(Lumo.STYLESHEET)
+public class AppShellConfiguratorImpl implements AppShellConfigurator {
+
+}

--- a/vcf-date-range-picker-demo/src/main/java/com/vaadin/componentfactory/demo/EnhancedDateRangePickerView.java
+++ b/vcf-date-range-picker-demo/src/main/java/com/vaadin/componentfactory/demo/EnhancedDateRangePickerView.java
@@ -22,15 +22,17 @@ import java.util.Locale;
 import com.vaadin.componentfactory.DateRange;
 import com.vaadin.componentfactory.EnhancedDateRangePicker;
 import com.vaadin.componentfactory.EnhancedDateRangePicker.DatePickerI18n;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H2;
+import com.vaadin.flow.component.html.Hr;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
-import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -40,10 +42,9 @@ import com.vaadin.flow.router.Route;
  */
 @Route("")
 @CssImport(value = "./styles/styles.css", themeFor = "vcf-date-range-month-calendar")
-public class EnhancedDateRangePickerView extends DemoView {
-
-    @Override
-    public void initView() {
+public class EnhancedDateRangePickerView extends VerticalLayout {
+    
+    public EnhancedDateRangePickerView() {      
         createPatternDatePicker();
         createPatternAndLocaleDatePicker();
         createSimpleDatePicker();
@@ -53,16 +54,11 @@ public class EnhancedDateRangePickerView extends DemoView {
         createFinnishDatePicker();
         createWithClearButton();
         createLocaleChangeDatePicker();
-
-        addCard("Additional code used in the demo",
-                new Span("These methods are used in the demo."));
     }
 
     private void createSimpleDatePicker() {
         Div message = createMessageDiv("simple-picker-message");
-
-        // begin-source-example
-        // source-example-heading: Simple date range picker
+        
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker();
         datePicker.setClassNameForDates("publicHolidayRed", LocalDate.now(), LocalDate.now().plusDays(10));
         datePicker.setClassNameForDates("publicHolidayGreen", LocalDate.now().plusDays(1), LocalDate.now().plusDays(11));
@@ -70,7 +66,6 @@ public class EnhancedDateRangePickerView extends DemoView {
 
         datePicker.addValueChangeListener(
                 event -> updateMessage(message, datePicker));
-        // end-source-example
 
         datePicker.setId("simple-picker");
 
@@ -80,8 +75,6 @@ public class EnhancedDateRangePickerView extends DemoView {
     private void createSimpleDatePickerWithoutTextFields() {
         Div message = createMessageDiv("simple-picker-without-text-fields-message");
 
-        // begin-source-example
-        // source-example-heading: Simple date range picker without visible text fields
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker();
         datePicker.setTextFieldsVisible(false);
         Button openDRP = new Button("Open Date Range Picker");
@@ -91,7 +84,6 @@ public class EnhancedDateRangePickerView extends DemoView {
 
         datePicker.addValueChangeListener(
                 event -> updateMessage(message, datePicker));
-        // end-source-example
 
         datePicker.setId("simple-picker");
 
@@ -101,8 +93,6 @@ public class EnhancedDateRangePickerView extends DemoView {
     private void createPatternDatePicker() {
         Div message = createMessageDiv("simple-picker-message");
 
-        // begin-source-example
-        // source-example-heading: Date range picker with pattern
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker(new DateRange(LocalDate.now(),LocalDate.now().plusDays(7)), "dd-MMM-yyyy");
         datePicker.setId("withCustomJSPreset");
         Button from1st = new Button("From 1st");
@@ -147,18 +137,17 @@ public class EnhancedDateRangePickerView extends DemoView {
             updateMessage(message, datePicker);
         });
 
-        // end-source-example
-
         datePicker.setId("Pattern-picker");
-
-        addCard("Date range picker with pattern", datePicker, message, patten, setPatternBtn, dropPatternBtn);
-    }
+        
+        VerticalLayout patternLayout = new VerticalLayout(patten, setPatternBtn, dropPatternBtn);
+        patternLayout.setPadding(false);
+        
+        addCard("Date range picker with pattern", datePicker, message, patternLayout);
+      }
 
     private void createPatternAndLocaleDatePicker() {
         Div message = createMessageDiv("simple-picker-message");
 
-        // begin-source-example
-        // source-example-heading: Date range picker with pattern and locale
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker(new DateRange(LocalDate.now(),null), "dd-MMM-yyyy");
 //        UI.getCurrent().setLocale(Locale.ITALIAN);
         updateMessage(message, datePicker);
@@ -184,7 +173,6 @@ public class EnhancedDateRangePickerView extends DemoView {
         HorizontalLayout patterns = new HorizontalLayout();
         patterns.add(setPatternBtn, dropPatternBtn);
 
-
         Button setlocaleBtn = new Button("Set locale to German");
         setlocaleBtn.addClickListener(e -> {
             datePicker.setLocale(Locale.GERMAN);
@@ -205,7 +193,6 @@ public class EnhancedDateRangePickerView extends DemoView {
 
         HorizontalLayout locales = new HorizontalLayout();
         locales.add(setlocaleBtn, setlocaleEsBtn, setLocaleEnBtn);
-        // end-source-example
 
         datePicker.setId("Pattern-picker");
 
@@ -215,8 +202,6 @@ public class EnhancedDateRangePickerView extends DemoView {
     private void createMinAndMaxDatePicker() {
         Div message = createMessageDiv("min-and-max-picker-message");
 
-        // begin-source-example
-        // source-example-heading: Date range picker with min and max without side panel
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker();
         datePicker.setLabel("Select a day within this month");
         datePicker.setPlaceholder("Date within this month");
@@ -229,38 +214,33 @@ public class EnhancedDateRangePickerView extends DemoView {
 
         datePicker.addValueChangeListener(
                 event -> updateMessage(message, datePicker));
-        // end-source-example
 
         datePicker.setId("min-and-max-picker");
+        
         addCard("Date range picker with min and max without side panel", datePicker, message);
     }
 
     private void createDisabledDatePicker() {
         Div message = createMessageDiv("disabled-picker-message");
 
-        // begin-source-example
-        // source-example-heading: Disabled date range picker
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker();
         datePicker.setEnabled(false);
-        // end-source-example
 
         datePicker.addValueChangeListener(event -> {
             message.setText("This event should not have happened");
         });
 
         datePicker.setId("disabled-picker");
+        
         addCard("Disabled date range picker", datePicker, message);
     }
 
     private void createWithClearButton() {
-        // begin-source-example
-        // source-example-heading: Clear button
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker();
         datePicker.setValue(new DateRange(LocalDate.now(),null));
 
         // Display an icon which can be clicked to clear the value:
         datePicker.setClearButtonVisible(true);
-        // end-source-example
 
         addCard("Clear button", datePicker);
     }
@@ -268,8 +248,6 @@ public class EnhancedDateRangePickerView extends DemoView {
     private void createFinnishDatePicker() {
         Div message = createMessageDiv("finnish-picker-message");
 
-        // begin-source-example
-        // source-example-heading: Internationalized date range picker
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker();
         datePicker.setLabel("Finnish date picker");
         datePicker.setPlaceholder("Syntymäpäivä");
@@ -310,16 +288,15 @@ public class EnhancedDateRangePickerView extends DemoView {
                 message.setText("No date is selected");
             }
         });
-        // end-source-example
 
         datePicker.setId("finnish-picker");
+        
         addCard("Internationalized date range picker", datePicker, message);
     }
 
     private void createLocaleChangeDatePicker() {
         Div message = createMessageDiv("Customize-locale-picker-message");
-        // begin-source-example
-        // source-example-heading: Date range picker with customize locales
+      
         // By default, the datePicker uses the current UI locale
         EnhancedDateRangePicker datePicker = new EnhancedDateRangePicker();
         NativeButton locale1 = new NativeButton("Locale: US");
@@ -341,16 +318,17 @@ public class EnhancedDateRangePickerView extends DemoView {
 
         datePicker.addValueChangeListener(
                 event -> updateMessage(message, datePicker));
-        // end-source-example
+        
         locale1.setId("Locale-US");
         locale2.setId("Locale-UK");
         datePicker.setId("locale-change-picker");
-        addCard("Date range picker with customize locales", datePicker, locale1,
-                locale2, locale3, message);
+        
+        VerticalLayout localeLayout = new VerticalLayout(locale1,
+            locale2, locale3);
+        
+        addCard("Date range picker with customize locales", datePicker, localeLayout, message);
     }
-    
-    // begin-source-example
-    // source-example-heading: Additional code used in the demo
+ 
     /**
      * Additional code used in the demo
      */
@@ -382,5 +360,18 @@ public class EnhancedDateRangePickerView extends DemoView {
         message.getStyle().set("whiteSpace", "pre");
         return message;
     }
-    // end-source-example
+    
+    private void addCard(String title, Component... content) {
+      H2 cardTitle = new H2(title);
+
+      Div card = new Div();
+      card.getStyle().setMargin("10px 30px");
+      card.getStyle().setMaxWidth("1000px");
+
+      card.add(cardTitle);
+      card.add(new Hr());
+      card.add(content);
+
+      add(card);
+    }
 }

--- a/vcf-date-range-picker/pom.xml
+++ b/vcf-date-range-picker/pom.xml
@@ -18,10 +18,10 @@
     </organization>
 
     <properties>
-        <vaadin.version>24.2.0</vaadin.version>
-        <flow.version>24.2.0</flow.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <vaadin.version>25.0.2</vaadin.version>
+        <flow.version>25.0.3</flow.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/vcf-date-range-picker/pom.xml
+++ b/vcf-date-range-picker/pom.xml
@@ -10,7 +10,7 @@
 
     <name>Date Range Picker</name>
 
-    <version>5.0.3-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <inceptionYear>2021</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/vcf-date-range-picker/src/main/java/com/vaadin/componentfactory/EnhancedDateRangePicker.java
+++ b/vcf-date-range-picker/src/main/java/com/vaadin/componentfactory/EnhancedDateRangePicker.java
@@ -58,7 +58,7 @@ import tools.jackson.databind.ObjectMapper;
 @JavaScript("./date-fns-limited.min.js")
 @JavaScript("./enhancedDateRangePickerConnector.js")
 @Tag("vcf-date-range-picker")
-@NpmPackage(value = "@vaadin-component-factory/vcf-date-range-picker", version = "5.0.2")
+@NpmPackage(value = "@vaadin-component-factory/vcf-date-range-picker", version = "6.0.0")
 @JsModule("@vaadin-component-factory/vcf-date-range-picker/vcf-date-range-picker.js")
 public class EnhancedDateRangePicker extends  AbstractSinglePropertyField<EnhancedDateRangePicker, DateRange>
         implements HasSize, HasValidation, HasComponents, HasClearButton, HasLabel {

--- a/vcf-date-range-picker/src/main/java/com/vaadin/componentfactory/EnhancedDateRangePicker.java
+++ b/vcf-date-range-picker/src/main/java/com/vaadin/componentfactory/EnhancedDateRangePicker.java
@@ -33,18 +33,18 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.shared.HasClearButton;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
-import com.vaadin.flow.internal.JsonSerializer;
 import com.vaadin.flow.shared.Registration;
-import elemental.json.JsonObject;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.jsoup.internal.StringUtil;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Server-side component that encapsulates the functionality of the
@@ -505,13 +505,15 @@ public class EnhancedDateRangePicker extends  AbstractSinglePropertyField<Enhanc
         getUI().ifPresent(ui -> setI18nWithJS());
     }
 
+    @SuppressWarnings("unchecked")
     private void setI18nWithJS() {
         runBeforeClientResponse(ui -> {
-            JsonObject i18nObject = (JsonObject) JsonSerializer.toJson(i18n);
-            for (String key : i18nObject.keys()) {
-                getElement().executeJs("this.set('i18n." + key + "', $0)",
-                        i18nObject.get(key));
-            }
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, Object> i18nMap = mapper.convertValue(i18n, Map.class);
+            i18nMap.forEach((key, value) -> {
+                getElement().executeJs("this.set('i18n." + key + "', $0)", value);
+            });
+            
         });
     }
 


### PR DESCRIPTION
~~This depends on release of version 6.0.0 of the web-component part which is [still in review](https://github.com/vaadin-component-factory/vcf-date-range-picker/pull/45).~~

Vaadin 25 compatible version, using web-component version [6.0.0](https://github.com/vaadin-component-factory/vcf-date-range-picker/releases/tag/6.0.0).